### PR TITLE
Switch connection pooling strategy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ impl ODBCConnection {
 
 lazy_static! {
     static ref ENV: Environment = unsafe {
-        Environment::set_connection_pooling(AttrConnectionPooling::DriverAware).unwrap();
+        Environment::set_connection_pooling(AttrConnectionPooling::OnePerDriver).unwrap();
         let mut env = Environment::new().unwrap();
         env.set_connection_pooling_matching(AttrCpMatch::Strict)
             .unwrap();


### PR DESCRIPTION
Since all connections use the same connection string, it is reasonable to assume the all use the same driver.